### PR TITLE
feat new props for select date

### DIFF
--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -18,7 +18,8 @@ const Calendar = memo(
     dayTextStyle,
     selectedDayTextColor,
     dayTextColor,
-    disabledTextColor
+    disabledTextColor,
+    onDateSelect
   }) => {
     const isSelected = day =>
       selected == fullDate(year, month, day, dateSeparator);
@@ -33,12 +34,14 @@ const Calendar = memo(
 
     const onChange = day => () =>
       onDateChange(fullDate(year, month, day, dateSeparator));
-
+    const onSelect = day => () =>
+      onDateSelect(fullDate(year, month, day, dateSeparator));
     const renderDay = ({ item }) => (
       <Day
         item={item}
         isSelected={isSelected(item)}
         onDateChange={onChange(item)}
+        onDateSelect={onSelect(item)}
         disabled={isDisabled(item)}
         dayStyle={dayStyle}
         selectedDayStyle={selectedDayStyle}

--- a/src/components/Day.js
+++ b/src/components/Day.js
@@ -6,6 +6,7 @@ const Day = memo(
   ({
     item,
     onDateChange,
+    onDateSelect,
     isSelected,
     disabled,
     dayStyle,
@@ -20,13 +21,16 @@ const Day = memo(
     if (blank) {
       return <View style={dayStyle} />;
     }
-
+    const setDate = () => {
+      if (isSelected) {
+        onDateSelect();
+      } else {
+        onDateChange();
+        onDateSelect();
+      }
+    };
     return (
-      <TouchableOpacity
-        style={dayStyle}
-        disabled={isSelected || disabled}
-        onPress={onDateChange}
-      >
+      <TouchableOpacity style={dayStyle} onPress={setDate}>
         <View
           style={[
             {

--- a/src/index.js
+++ b/src/index.js
@@ -185,6 +185,7 @@ class DatePicker extends PureComponent {
       minDate,
       maxDate,
       onDateChange,
+      onDateSelect,
       dayStyle,
       selectedDayStyle,
       selectedDayColor,
@@ -211,6 +212,7 @@ class DatePicker extends PureComponent {
         selectedDayTextColor={selectedDayTextColor}
         dayTextColor={dayTextColor}
         disabledTextColor={disabledTextColor}
+        onDateSelect={onDateSelect}
       />
     );
   }

--- a/src/props.js
+++ b/src/props.js
@@ -17,6 +17,7 @@ export const DEFAULT_PROPS = {
   minDate: lastYear(),
   maxDate: nextYear(),
   onDateChange: date => console.warn(date),
+  onDateSelect: date => {},
 
   // Header
   headerContainerStyle: { height: '15%' },


### PR DESCRIPTION
new feature: 
new prop onDateSelect added
that triggered when the user select a date and will return the selected date
why:
this feature is so useful when we want a date even if it's selected
how: 
I have written condition in day.js file that checks if touched date is selected or not and based on that condition 
onDateSelect and onDateChange
would be called